### PR TITLE
Added allow merge functionality to batch decorators so that we can me…

### DIFF
--- a/metaflow/plugins/aws/step_functions/step_functions_cli.py
+++ b/metaflow/plugins/aws/step_functions/step_functions_cli.py
@@ -286,8 +286,10 @@ def make_flow(
     if decospecs:
         decorators._attach_decorators(obj.flow, decospecs)
 
-    # Attach AWS Batch decorator to the flow
-    decorators._attach_decorators(obj.flow, [BatchDecorator.name])
+    if len(decospecs) == 0:
+        # Don't merge here, cause things with static decorators should not be needed to be passed again
+        decorators._attach_decorators(obj.flow, [BatchDecorator.name],merge=False)
+
     decorators._init_step_decorators(
         obj.flow, obj.graph, obj.environment, obj.flow_datastore, obj.logger
     )


### PR DESCRIPTION
Created allow merge functionality when adding decorators to step, this is entered when static batch decorator has already been added to a step and want to merge parameters available in `with batch` cli argument without overwriting arguments specified in the static batch decorator.
Needed to override the function `_parse_decorator_spec` in batch decorator in order to achieve the result above.

Tested the above by deploying on AWS cli using with batch argument and without:
With
```
aws-vault exec be-dev -- python brain-engine/erf_flow.py --no-pylint  step-functions create --with batch:cpu=2,memory=15000,image=785965938585.dkr.ecr.ap-southeast-2.amazonaws.com/brain-engine-image:1ecc39382a9c1b65ee3dd141d03c4fc326cfab95,efs_volumes=fs-086ca90671967b53c@/root/workspace
```
Without
```
aws-vault exec be-dev -- python brain-engine/erf_flow.py --no-pylint  step-functions create
```
Also tested locally with brain-engine

